### PR TITLE
Fixed ruff (PEP8) codestyle error

### DIFF
--- a/lectures/05. Функции. Классы. Типизация/Lecture_05.ipynb
+++ b/lectures/05. Функции. Классы. Типизация/Lecture_05.ipynb
@@ -481,7 +481,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from typing import Literal, List\n",
+    "from typing import Literal\n",
     "\n",
     "\n",
     "def create_mythical_creature(\n",


### PR DESCRIPTION
'typing.List' was imported but unused (F401) in Lecture 5